### PR TITLE
SSO: Share session to subdomains, SSO: Cleanup

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php')
 ?>
 
@@ -23,7 +22,6 @@ require('session_validation.php')
 
 <body>
     <?PHP
-    //session_start();
     echo getTopNav();
     ?>
     <br>

--- a/addWordPair.php
+++ b/addWordPair.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require('add_words_process.php');
 ?>

--- a/add_images.php
+++ b/add_images.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require('session_validation.php');
 require 'db_configuration.php';
 

--- a/add_many_words_one_image.php
+++ b/add_many_words_one_image.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require('db_configuration.php');
 require('InsertUtil.php');

--- a/add_puzzle.php
+++ b/add_puzzle.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require_once('add_puzzle_process.php');
 require_once('utility_functions.php');

--- a/add_word.php
+++ b/add_word.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 

--- a/add_words.php
+++ b/add_words.php
@@ -1,5 +1,4 @@
 <?PHP
-    session_start();
 	require('session_validation.php');
 	require('db_configuration.php');
     require('InsertUtil.php');

--- a/admin.php
+++ b/admin.php
@@ -1,5 +1,4 @@
 <?php
-  session_start();
   require('session_validation.php');
   echo getTopNav();
 ?>

--- a/admin_edit_synonyms.php
+++ b/admin_edit_synonyms.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require_once('db_configuration.php');
 require_once('create_puzzle.php');

--- a/admin_manage_users.php
+++ b/admin_manage_users.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 include('admin_manage_users_helper.php')
 ?>

--- a/change_puzzle.php
+++ b/change_puzzle.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require_once('add_puzzle_process.php');
 require_once('utility_functions.php');

--- a/create_user.php
+++ b/create_user.php
@@ -1,10 +1,5 @@
 <?php
-session_start();
 require('session_validation.php');
-// $status = session_status();
-// if ($status == PHP_SESSION_NONE) {
-//     session_start();
-// }
 
 //require 'bin/functions.php';
 require 'db_configuration.php';

--- a/force_sync.php
+++ b/force_sync.php
@@ -1,5 +1,4 @@
 <?php
-    session_start();
     require('session_validation.php');
     set_time_limit(1000);
 // ================ Includes ================

--- a/generate_many_from_a_list.php
+++ b/generate_many_from_a_list.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/generate_multiple_puzzles.php
+++ b/generate_multiple_puzzles.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/generate_puzzle_from_list.php
+++ b/generate_puzzle_from_list.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/generate_puzzle_with_exclusion_list.php
+++ b/generate_puzzle_with_exclusion_list.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/generate_puzzles.php
+++ b/generate_puzzles.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/generate_puzzles_bak.php
+++ b/generate_puzzles_bak.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/includes/session_start.php
+++ b/includes/session_start.php
@@ -1,0 +1,6 @@
+<?php
+if (session_status() == PHP_SESSION_NONE) {
+    // set the cookie params in order to find the main domain's session
+    session_set_cookie_params(0, '/', '.telugupuzzles.com');
+    session_start();
+}

--- a/index.php
+++ b/index.php
@@ -1,10 +1,5 @@
 <?php
 require('session_validation.php');
-if (isset($_GET['session_id'])) {
-  require_once('user_sessions.php');
-  create_session($_GET['session_id']);
-  header('location: index.php');
-}
 ?>
 <!DOCTYPE html>
 <html>

--- a/index.php
+++ b/index.php
@@ -1,11 +1,10 @@
 <?php
-session_start();
+require('session_validation.php');
 if (isset($_GET['session_id'])) {
   require_once('user_sessions.php');
   create_session($_GET['session_id']);
   header('location: index.php');
 }
-require('session_validation.php');
 ?>
 <!DOCTYPE html>
 <html>

--- a/list.php
+++ b/list.php
@@ -1,14 +1,11 @@
 <?php //include 'navbar.php';
-session_start();
 require('session_validation.php');
 // Start session to store variables
 
 if (!isset($_SESSION)) {
     ini_set('session.cache_limiter', 'public');
     session_cache_limiter(false);
-
-    session_start();
-
+    require_once 'includes/session_start.php';
 }
 
 // Allows user to return 'back' to this page

--- a/list_puzzles.php
+++ b/list_puzzles.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>
@@ -46,7 +45,6 @@ require('session_validation.php');
         </thead>
         <tbody>
           <?php
-          //session_start();
           $sql = 'SELECT * FROM puzzles ORDER BY puzzle_name, puzzle_id;';
           $db = new mysqli(DATABASE_HOST, DATABASE_USER, DATABASE_PASSWORD, DATABASE_DATABASE);
           $db->set_charset("utf8");

--- a/list_with_column_toggling.php
+++ b/list_with_column_toggling.php
@@ -1,14 +1,11 @@
 <?php //include 'navbar.php';
-session_start();
 require('session_validation.php');
 // Start session to store variables
 
 if (!isset($_SESSION)) {
     ini_set('session.cache_limiter', 'public');
     session_cache_limiter(false);
-
-    session_start();
-
+    require_once 'includes/session_start.php';
 }
 
 // Allows user to return 'back' to this page

--- a/list_words.php
+++ b/list_words.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 //require ('list.php');
 ?>

--- a/manageUsers.php
+++ b/manageUsers.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require('db_configuration.php');
 ?>
@@ -27,7 +26,6 @@ $result = run_sql($sql);
 
 <body>
 <?PHP
-session_start();
 echo getTopNav();
 
 echo '<div>

--- a/many_From_A_list.php
+++ b/many_From_A_list.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/many_to_one.php
+++ b/many_to_one.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/one_from_a_given_list.php
+++ b/one_from_a_given_list.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/one_to_many.php
+++ b/one_to_many.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/one_to_many_plus.php
+++ b/one_to_many_plus.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/print_given_puzzles.php
+++ b/print_given_puzzles.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/print_puzzle.php
+++ b/print_puzzle.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/puzzle.php
+++ b/puzzle.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 require_once('create_puzzle.php');
 require_once('common_sql_functions.php');

--- a/puzzle_list.php
+++ b/puzzle_list.php
@@ -1,15 +1,6 @@
 <?php //include 'navbar.php';
-session_start();
 require('session_validation.php');
 // Start session to store variables
-
-if(!isset($_SESSION))
-
-{
-
-    session_start();
-
-}
 
 // Allows user to return 'back' to this page
 

--- a/puzzle_with_exclusion.php
+++ b/puzzle_with_exclusion.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/report.php
+++ b/report.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>

--- a/session_validation.php
+++ b/session_validation.php
@@ -1,9 +1,6 @@
 <?php
-$status = session_status();
-if ($status == PHP_SESSION_NONE) {
-     session_start();
-}
-require_once('user_sessions.php');
+require_once 'includes/session_start.php';
+require_once 'user_sessions.php';
 
 	/**
 	 * Returns true if user has a valid
@@ -25,7 +22,7 @@ require_once('user_sessions.php');
 	 * normal navbar
 	 */
 	function getTopNav() {
-		session_start();
+		require_once 'includes/session_start.php';
 		$topNav = "";
 		if (adminSessionExists()) {
 			$topNav = '<nav class="navbar navbar-default" role="navigation" style="background-color: transparent;">
@@ -74,7 +71,7 @@ require_once('user_sessions.php');
 				<a href="./puzzle_list.php"><button id="list" class="navOption">List</button></a>
 			</li>
 			<li>
-				<a href="./about.php"><button id="addword" class="navOption">Abour</button></a>
+				<a href="./about.php"><button id="addword" class="navOption">About</button></a>
 			</li>
 			<!--<li>
 				<a href="./addWordPair.php"><button id="addpuzzle" class="navOption">Add<br> Word<br> Pairs</button></a>

--- a/uploadPage.php
+++ b/uploadPage.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 //require('import.php');
 /*
@@ -29,7 +28,6 @@ else{
 </head>
 <body>
 <?PHP
-session_start();
 echo getTopNav();
 ?>
 <div id="export">

--- a/userManual.php
+++ b/userManual.php
@@ -1,5 +1,4 @@
 <?PHP
-session_start();
 require('session_validation.php');
 ?>
 <!DOCTYPE html>
@@ -22,7 +21,6 @@ require('session_validation.php');
 
 <body>
 <?PHP
-//session_start();
 echo getTopNav();
 ?>
 <br>

--- a/user_sessions.php
+++ b/user_sessions.php
@@ -1,6 +1,6 @@
 <?php
-session_start();
-/* Local testing 
+require_once 'includes/session_start.php';
+///* Local testing 
 // user sessions database information
 DEFINE('USER_SESSIONS_DATABASE_HOST', 'localhost');
 DEFINE('USER_SESSIONS_DATABASE_NAME', 'puzzleapps_db');
@@ -12,20 +12,6 @@ $app_id = 5;
 DEFINE('LOGIN_LINK', "http://localhost/telugupuzzles/login.php?app_id=" . $app_id);
 DEFINE('LOGOUT_LINK', "http://localhost/telugupuzzles/logout.php");
 DEFINE('REGISTER_LINK', "http://localhost/telugupuzzles/register.php?app_id==" . $app_id);
-/**/
-
-/* live */
-// user sessions database information TODO: REMOVE BEFORE GITHUB
-DEFINE('USER_SESSIONS_DATABASE_HOST', 'localhost');
-DEFINE('USER_SESSIONS_DATABASE_NAME', 'icsbinco_indicpuzzles_db');
-DEFINE('USER_SESSIONS_DATABASE_USERNAME', 'icsbinco_indic_puzzles');
-DEFINE('USER_SESSIONS_DATABASE_PASSWORD', 'indic_puzzles_123');
-// this app's id
-$app_id = 5; // TODO: check what this is
-// links
-DEFINE('LOGIN_LINK', "http://telugupuzzles.com/login.php?app_id=" . $app_id);
-DEFINE('LOGOUT_LINK', "http://telugupuzzles.com/logout.php");
-DEFINE('REGISTER_LINK', "http://telugupuzzles.com/register.php?app_id==" . $app_id);
 /**/
 
 /**

--- a/user_sessions.php
+++ b/user_sessions.php
@@ -52,9 +52,6 @@ function get_session_info($session_id) {
         $stmt->execute();
 
         if ($result = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            // reset the allow-login boolean
-            reset_allow_login($session_id, $sessions_pdo);
-
             return $result;
         } else {
             return null;
@@ -98,86 +95,11 @@ function user_has_access_to_app($user_id) {
 }
 
 /**
- * A function to create a session (log in) for this application.
- * 
- * @param $session_id The session id on telugupuzzles
- * @return True if the session was created successfully, false otherwise
- */
-function create_session($session_id) {
-    $session_info = get_session_info($session_id);
-    
-    if (is_null($session_info)) {
-        // no session info available
-        return false;
-    } else {
-        if ($session_info['allow_login']) { // check user is allowed to login
-            // indicate that the user has access to this app
-            if (user_has_access_to_app($session_info['id'])) {
-                $_SESSION['author'] = true;
-            }
-
-            $_SESSION['user_id'] = $session_info['id'];
-            $_SESSION['email'] = $session_info['email'];
-            $_SESSION['first_name'] = $session_info['first_name'];
-            $_SESSION['last_name'] = $session_info['last_name'];
-            $_SESSION['role'] = $session_info['role'];
-            $_SESSION['logged_in'] = true;
-
-            return true;
-        } else {
-            return false;
-        }
-    }
-}
-
-/**
- * A function to set 'allow_login' to false in the database. This prevents someone using the session id
- *  to log in to someone's account after they have logged in.
- * 
- * @param $session_id The session id to set 'allow_login' for
- * @param $session_pdo The pdo connectiont to the database
- */
-function reset_allow_login($session_id, $sessions_pdo = null) {
-    if (is_null($sessions_pdo)) {
-        try {
-            $sessions_pdo = connect_to_user_sessions_db();
-            // set the PDO error mode to exception
-            $sessions_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    
-            // prepared statement
-            $stmt = $sessions_pdo->prepare("UPDATE user_sessions SET allow_login=false WHERE session_id=:session_id");
-            $stmt->bindParam(':session_id', $session_id);
-            $stmt->execute();
-        } catch(PDOException $e) {
-            echo "Error: " . $e->getMessage();
-        }
-    } else {
-        // prepared statement
-        $stmt = $sessions_pdo->prepare("UPDATE user_sessions SET allow_login=false WHERE session_id=:session_id");
-        $stmt->bindParam(':session_id', $session_id);
-        $stmt->execute();
-    }
-}
-
-/**
  * A function to log a user out of the app, then redirect to log out of telugupuzzles.
  */
 function logout() {
-    reset_allow_login(session_id()); // double check allow login is set to false
-
-    // clear the session variables
-    unset($_SESSION['user_id']);
-    unset($_SESSION['email']);
-    unset($_SESSION['first_name']);
-    unset($_SESSION['last_name']);
-    unset($_SESSION['role']);
-    unset($_SESSION['logged_in']);
-    unset($_SESSION['author']);
-    $_SESSION = array();
-
-    setcookie(session_name(),'',0,'/'); // clear the session cookie
-    session_regenerate_id(true); // change the session id
-    session_destroy(); // destroy the session
+    // clear the session variable for this app
+    unset($_SESSION['rebus_author']);
 
     // redirect to telugupuzzles
     header("location: " . LOGOUT_LINK);
@@ -190,23 +112,29 @@ function logout() {
  */
 function is_logged_in() {
     if (isset($_SESSION['logged_in'])) {
-        return true;
+        if ($_SESSION['logged_in']) {
+            return true;
+        }
     }
-    
     return false;
 }
 
 /**
- * A function to check if the user has author access to the app.
+ * A function to check if the user has author access to the app. If the author access session
+ *  variable is not set, this will set it.
  * 
+ * @param $user_id The id of the user
  * @return True if the user has author access, false otherwise.
  */
-function is_author() {
-    if (isset($_SESSION['author'])) {
-        return true;
-    } else {
-        return false;
+function is_author($user_id) {
+    if (!isset($_SESSION['rebus_author'])) {
+        if (user_has_access_to_app($user_id)) {
+            $_SESSION['rebus_author'] = true;
+        } else {
+            $_SESSION['rebus_author'] = false;
+        }
     }
+    return $_SESSION['rebus_author'];
 }
 
 /**


### PR DESCRIPTION
SSO: Share session to subdomains
- Adjustment before session_start() to allow subdomains to use the same session as the main domain (telugupuzzles) for login.

SSO: Cleanup
- Removed some functionality made unnecessary by the previous "SSO: Share session to subdomains" commit.